### PR TITLE
Add experimental Arctis Nova Elite support

### DIFF
--- a/ggoled_lib/src/lib.rs
+++ b/ggoled_lib/src/lib.rs
@@ -335,7 +335,13 @@ impl Device {
         Ok(())
     }
 
-    fn parse_event(buf: &[u8; 64]) -> Vec<DeviceEvent> {
+    // `buf[0]` is the HID report ID of the *incoming* report. On Nova Pro, unsolicited
+    // push events (volume/connection/battery) come in tagged with report id 7, while
+    // replies to commands we send come back tagged with the same id we sent (6). The
+    // Nova Elite only declares a single input report id (`self.info_report_id`, 7) for
+    // its info collection, so on that device command replies also come back as 7 -
+    // hence matching against `self.info_report_id` rather than the literal `0x06`.
+    fn parse_event(&self, buf: &[u8; 64]) -> Vec<DeviceEvent> {
         #[cfg(debug_assertions)]
         println!("parse_event: {:x?}", buf);
         match (buf[0], buf[1]) {
@@ -356,7 +362,7 @@ impl Device {
             // 0-8 values for battery levels
             // we handle both event and command reply the same (because they look the same)
             // can fetch this info with a [0x06, 0xb7] command, but [0x06, 0xb0] seems superior (?)
-            (0x07, 0xb7) | (0x06, 0xb7) => vec![DeviceEvent::Battery {
+            (0x07, 0xb7) => vec![DeviceEvent::Battery {
                 headset: buf[2],
                 charging: buf[3],
                 // NOTE: there's a possibility `buf[4]` represents either the max value or simply just `8` for connected
@@ -364,25 +370,25 @@ impl Device {
 
             // --- command responses ---
 
-            // version info, fetch with [0x06, 0x10]
+            // version info, fetch with [<id>, 0x10]
             // basically useless for us so not implemented
-            (0x06, 0x10) => vec![],
+            (id, 0x10) if id == self.info_report_id => vec![],
 
-            // [0x06, 0x20] returns a bunch of info
+            // [<id>, 0x20] returns a bunch of info
             // same regardless of connected state
             // i think some of it is equalizer levels, but i've got no idea what the rest is
-            (0x06, 0x20) => vec![DeviceEvent::Volume {
+            (id, 0x20) if id == self.info_report_id => vec![DeviceEvent::Volume {
                 volume: 0x38u8.saturating_sub(buf[3]), // NOTE: different byte from Volume event
             }],
 
-            // unknown data, fetch with [0x06, 0x80]
+            // unknown data, fetch with [<id>, 0x80]
             // same regardless of connected state
             // not implemented
-            (0x06, 0x80) => vec![],
+            (id, 0x80) if id == self.info_report_id => vec![],
 
             // various data
             // there's a couple of bytes i've got no idea what they're supposed to represent
-            (0x06, 0xb0) => vec![
+            (id, 0xb0) if id == self.info_report_id => vec![
                 DeviceEvent::HeadsetConnection {
                     wireless: buf[15] == 8,
                     bluetooth: buf[5] == 1,
@@ -395,6 +401,12 @@ impl Device {
                 },
             ],
 
+            // command reply variant of the 0xb7 battery event above
+            (id, 0xb7) if id == self.info_report_id => vec![DeviceEvent::Battery {
+                headset: buf[2],
+                charging: buf[3],
+            }],
+
             _ => vec![],
         }
     }
@@ -404,7 +416,7 @@ impl Device {
         let mut buf = [0u8; 64];
         self.dev.info().set_blocking_mode(true)?;
         _ = self.dev.info().read(&mut buf)?;
-        Ok(Self::parse_event(&buf))
+        Ok(self.parse_event(&buf))
     }
 
     /// Return any pending events from the device. Non-blocking.
@@ -417,7 +429,7 @@ impl Device {
             if len == 0 {
                 break;
             } else {
-                events.append(&mut Self::parse_event(&buf));
+                events.append(&mut self.parse_event(&buf));
             }
         }
         Ok(events)

--- a/ggoled_lib/src/lib.rs
+++ b/ggoled_lib/src/lib.rs
@@ -61,6 +61,8 @@ pub struct Device {
     dev: DeviceMerge,
     pub width: usize,
     pub height: usize,
+    oled_report_id: u8,
+    info_report_id: u8,
 }
 impl Device {
     /// Connect to a SteelSeries GG device.
@@ -78,7 +80,11 @@ impl Device {
             0x12e0, // Arctis Nova Pro Wireless
             0x12e5, // Arctis Nova Pro Wireless (Xbox)
             0x225d, // Arctis Nova Pro Wireless (Xbox White)
-        ].contains(&d.product_id()) && d.interface_number() == 4
+            0x2244, // Arctis Nova Elite (base station, unofficial/untested - see issue #26)
+        ].contains(&d.product_id())
+            // Nova Elite base station exposes the OLED/info collections on interface 3, not 4
+            // (interface 4 there is an unrelated consumer-control/media-key interface).
+            && d.interface_number() == if d.product_id() == 0x2244 { 3 } else { 4 }
             })
             .collect();
 
@@ -90,6 +96,13 @@ impl Device {
         } else if device_infos.len() > 2 {
             bail!("Too many matching devices connected");
         }
+
+        // The HID report IDs differ by product; Nova Pro uses 6 for both the OLED and
+        // info collections, but the Nova Elite base station declares report ID 1 for its
+        // OLED collection (Col01) and report ID 7 for its info collection (Col02).
+        let is_nova_elite = device_infos[0].product_id() == 0x2244;
+        let oled_report_id: u8 = if is_nova_elite { 0x01 } else { 0x06 };
+        let info_report_id: u8 = if is_nova_elite { 0x07 } else { 0x06 };
 
         // On Linux, both devices can get put under the same hidraw interface, meaning we use the same device for both
         let dev = if device_infos[0].path() == device_infos[1].path() {
@@ -143,6 +156,8 @@ impl Device {
             dev,
             width: SCREEN_WIDTH,
             height: SCREEN_HEIGHT,
+            oled_report_id,
+            info_report_id,
         })
     }
 
@@ -193,7 +208,7 @@ impl Device {
     // The Bitmap must already be within the report limits (from `split_for_report`)
     fn create_report(&self, d: &ReportDrawable) -> DrawReport {
         let mut report: DrawReport = [0; SCREEN_REPORT_SIZE];
-        report[0] = 0x06; // hid report id
+        report[0] = self.oled_report_id; // hid report id
         report[1] = 0x93; // command id
         report[2] = d.dst_x as u8;
         report[3] = d.dst_y as u8;
@@ -292,7 +307,7 @@ impl Device {
             bail!("brightness too high");
         }
         let mut report = [0; 64];
-        report[0] = 0x06; // hid report id
+        report[0] = self.oled_report_id; // hid report id
         report[1] = 0x85; // command id
         report[2] = value;
         self.dev.oled().write(&report)?;
@@ -303,7 +318,7 @@ impl Device {
     /// Data is received via events.
     pub fn probe(&self) -> anyhow::Result<()> {
         let mut report = [0; 64];
-        report[0] = 0x06; // hid report id
+        report[0] = self.info_report_id; // hid report id
         report[1] = 0xb0; // command id, get various data
         self.dev.info().write(&report)?;
         report[1] = 0x20; // command id, get volume info
@@ -314,7 +329,7 @@ impl Device {
     /// Return to SteelSeries UI.
     pub fn return_to_ui(&self) -> anyhow::Result<()> {
         let mut report = [0; 64];
-        report[0] = 0x06; // hid report id
+        report[0] = self.oled_report_id; // hid report id
         report[1] = 0x95; // command id
         self.dev.oled().write(&report)?;
         Ok(())


### PR DESCRIPTION
Adds experimental support for the Arctis Nova Elite base station (PID `0x2244`), tested against real hardware. Related: #26

Two things beyond just adding the PID to the match list:

1. **Wrong interface.** The base station exposes its OLED/info HID collections on interface 3, not interface 4 like the Nova Pro (interface 4 there is an unrelated consumer-control/media-key interface). Confirmed via `ggoled dump-devices`.
2. **Wrong HID report IDs.** Every currently-supported device uses report ID 6 for both the OLED and info feature reports. The Nova Elite's descriptors declare report ID 1 for the OLED collection (Col01) and report ID 7 for the info collection (Col02). Sending report ID 6 fails with `HidD_SetFeature: The parameter is incorrect` on Windows.

Confirmed working: `clear`, `fill`, `text`, `img`, `brightness`, `return`, and the `ggoled_app` tray daemon (time/media display).

**Known gap:** the info-event parsing table (`parse_event`, battery/volume readouts) still assumes report ID 6 in several match arms and hasn't been updated for this device, so those event readouts are likely still incorrect here. Screen drawing is unaffected.

Happy to adjust the approach if you'd prefer detecting the interface/report IDs from descriptor content rather than hardcoding on PID.